### PR TITLE
Remove “use :monitor” dependency from persistence component

### DIFF
--- a/lib/snowflakes/components/persistence.rb
+++ b/lib/snowflakes/components/persistence.rb
@@ -13,7 +13,6 @@ Dry::System.register_component(:persistence, provider: :snowflakes) do
     require "rom/sql"
 
     use :settings
-    use :monitor
 
     ROM::SQL.load_extensions(*config.global_extensions)
 


### PR DESCRIPTION
monitor isn’t provided by snowflakes and we shouldn’t rely on apps to provide it (plus, I’ve lately been renaming it to sql_logger, which stops the persistence component from being able to boot properly)